### PR TITLE
feat: forward rawBody & hmacSignature on emit

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,21 @@
-/* eslint-disable no-param-reassign */
-const app = require('express')();
-const bodyParser = require('body-parser');
-const server = require('http').createServer(app);
-const io = require('socket.io')(server);
-const Chance = require('chance');
+/* eslint-disable no-param-reassign, no-console */
+const crypto = require('crypto');
+const http = require('http');
+const express = require('express');
+const socketIo = require('socket.io');
 
-const chance = new Chance();
+const app = express();
+const server = http.createServer(app);
+const io = socketIo(server);
+
 const clients = {};
 
+const { PORT } = process.env;
+
+const NELLO_HMAC_HEADER = 'x-nello-hook-hmac';
+
 function generateRandomWebhookName() {
-  return `${chance
-    .sentence({ words: 5 })
-    .replace(/ /g, '-')
-    .toLowerCase()
-    .replace(/\./g, '')}-${chance.integer({ min: 0, max: 9999 })}`;
+  return crypto.randomBytes(32).toString('hex');
 }
 
 function handleWebhook(socket) {
@@ -34,21 +36,37 @@ function handleWebhook(socket) {
   });
 }
 
-app.use(bodyParser.json());
-app.use((req, res) => {
-  const client = clients[req.path.replace('/callback/', '')];
+app.use(express.text({ type: '*/*' }));
+app.put('/callback/:clientId', (req, res) => {
+  const client = clients[req.params.clientId];
+
   if (!client) {
     res.status(404).send('Not Found');
     return;
   }
 
-  client.emit('call', req.body);
+  const jsonString = req.body;
+  const header = req.header(NELLO_HMAC_HEADER);
+
+  try {
+    client.emit('call', {
+      ...JSON.parse(req.body),
+      rawBody: jsonString,
+      hmacSignature: header,
+    });
+  } catch (e) {
+    console.error('Error parsing/emitting webhook data', e);
+  }
+
   res.status(200).send('OK');
 });
 
 io.on('connection', (socket) => {
   handleWebhook(socket);
-  socket.on('getWebhook', () => handleWebhook(socket));
+
+  socket.on('getWebhook', () => {
+    handleWebhook(socket);
+  });
 
   socket.on('disconnect', () => {
     if (socket.callbackName) {
@@ -57,4 +75,4 @@ io.on('connection', (socket) => {
   });
 });
 
-server.listen(process.env.PORT);
+server.listen(PORT);

--- a/package.json
+++ b/package.json
@@ -9,8 +9,6 @@
   "author": "Alexander Babel",
   "license": "ISC",
   "dependencies": {
-    "body-parser": "^1.18.3",
-    "chance": "^1.0.16",
     "express": "^4.16.3",
     "socket.io": "^2.1.1"
   },


### PR DESCRIPTION
The idea here is to allow user-controlled code to perform the validation. The rawBody and HMAC signature can be verified by the homebridge-nello plugin. This backend does not need to know the pre-shared key and therefore, by design, cannot tamper with the data.

The parsed body is retained to maintain backwards-compatibility, but could be eventually removed.

Proposed handling: https://github.com/lukasroegner/homebridge-nello/pull/56